### PR TITLE
A bit of work towards PHP 8.2 compatibility

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/CompositeDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/CompositeDataSet.php
@@ -23,7 +23,7 @@
  */
 class PHPUnit_Extensions_Database_DataSet_CompositeDataSet extends PHPUnit_Extensions_Database_DataSet_AbstractDataSet
 {
-    protected $motherDataSet;
+    protected $motherDataset;
 
     /**
      * Creates a new Composite dataset

--- a/PHPUnit/Extensions/Database/DataSet/ReplacementTableIterator.php
+++ b/PHPUnit/Extensions/Database/DataSet/ReplacementTableIterator.php
@@ -149,6 +149,7 @@ class PHPUnit_Extensions_Database_DataSet_ReplacementTableIterator implements Ou
         return $this->innerIterator->valid();
     }
 
+	#[ReturnTypeWillChange]
     public function getInnerIterator()
     {
         return $this->innerIterator;


### PR DESCRIPTION
I'm running all zf1 tests against PHP 8.2 and there are several tests left failing because of the typo in the property name:

`\PHPUnit_Extensions_Database_DataSet_CompositeDataSet::$motherDataset`

Also, `\PHPUnit_Extensions_Database_DataSet_ReplacementTableIterator::getInnerIterator` needs `#[ReturnTypeWillChange]`

There are more things to fix, but these are the only ones that were surfacing while running zf1 tests